### PR TITLE
add page titles and descriptions

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -10,6 +10,7 @@ require('dotenv').config({
 const open = require('open')
 const chalk = require('chalk')
 const prompts = require('prompts')
+const startCase = require('lodash/startCase')
 const { initSearch } = require('../src/search')
 
 const search = initSearch()
@@ -63,7 +64,7 @@ const getHighlight = (hit) => {
 const options = {
   type: 'autocomplete',
   name: 'value',
-  message: 'cy 🔎',
+  message: '🔍 Search Cypress Docs',
   choices: [],
   suggest(input, choices) {
     choices.length = 0
@@ -81,10 +82,12 @@ const options = {
           title: hit.url,
         })
         const highlight = getHighlight(hit)
-        const title = highlight ? hit.url + ' ' + highlight : hit.url
+        const url = new URL(hit.url)
+        const title = highlight ? highlight : startCase(url.hash)
         return {
           title,
           value: hit.url,
+          description: url.pathname
         }
       })
     })

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/node": "14.14.5",
+    "lodash": "^4.17.20",
     "prettier": "2.1.2",
     "semantic-release": "^17.2.1"
   },


### PR DESCRIPTION
I added a couple of tweaks to the search. For me, it was kinda hard to read through all the links, so I’m parsing the url hash and provide pathname as a description.

Looks something like this:
![Screen Recording 2020-10-27 at 12 48 00](https://user-images.githubusercontent.com/23213553/97297993-147caf80-1853-11eb-8b2d-6055209579dc.gif)

Let me know what you think.