### PR TITLE
fix encoding titles and decoding urls

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -10,7 +10,6 @@ require('dotenv').config({
 const open = require('open')
 const chalk = require('chalk')
 const prompts = require('prompts')
-const startCase = require('lodash.startcase')
 const { initSearch } = require('../src/search')
 
 const search = initSearch()
@@ -61,6 +60,11 @@ const getHighlight = (hit) => {
   })
 }
 
+const getTitle = (hash) => {
+  const result = decodeURI(hash).replace(/-/g, ' ').replace(/#/, '')
+  return result
+}
+
 const options = {
   type: 'autocomplete',
   name: 'value',
@@ -83,10 +87,10 @@ const options = {
         })
         const highlight = getHighlight(hit)
         const url = new URL(hit.url)
-        const title = highlight ? highlight : startCase(url.hash)
+        const title = highlight ? highlight : getTitle(url.hash)
         return {
           title,
-          value: hit.url,
+          value: encodeURI(hit.url),
           description: url.pathname,
         }
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1593,11 +1593,6 @@
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
       "dev": true
     },
-    "lodash.startcase": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
-    },
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "algoliasearch": "4.1.0",
     "chalk": "3.0.0",
     "dotenv": "8.2.0",
-    "lodash.startcase": "4.4.0",
     "open": "7.0.3",
     "prompts": "2.3.2"
   },


### PR DESCRIPTION
- removed lodash because it was parsing out apostrophes
- added `getTitle` function, which decodes url hash (`URL()` constructor encodes it, ugh) and then replace unwanted characters
- added encoding of result value, since `open` package had troubles opening it when it was encoded

fixes #5  